### PR TITLE
FIX LEAKS && ADD TDD FOR WALLS:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ INCS		=	-I include\
 RM			=	rm -rf
 SILENT		=	--no-print-directory -s
 
+VALGRIND	=	valgrind --leak-check=full --show-leak-kinds=all
+
 #############################################################################
 #							LIBRARIES										#
 #############################################################################
@@ -108,11 +110,16 @@ test:	re
 		./$(NAME) maps/default.cub
 
 vtest:	re
-		valgrind --leak-check=full --show-leak-kinds=all -s ./$(NAME) maps/default.cub
+		$(VALGRIND) ./$(NAME) maps/default.cub
 
 test_map:	$(LIBFT) $(MLX)
 		$(CC) $(CFLAGS) srcs/test/main_map_tester.c srcs/parsing/check_map_name.c srcs/parsing/check_map_content.c srcs/parsing/check_wall_texture_functions.c srcs/parsing/check_ceilling_floor_texture_functions.c srcs/parsing/map_to_list.c srcs/utils/free_functions.c srcs/utils/error_message.c $(LIBFT) $(LIBS) -o $(NAME) $(INCS)
 		./srcs/test/test_maps.sh
+
+vtest_map:	$(LIBFT) $(MLX)
+		$(CC) $(CFLAGS) srcs/test/main_map_tester.c srcs/parsing/check_map_name.c srcs/parsing/check_map_content.c srcs/parsing/check_wall_texture_functions.c srcs/parsing/check_ceilling_floor_texture_functions.c srcs/parsing/map_to_list.c srcs/utils/free_functions.c srcs/utils/error_message.c $(LIBFT) $(LIBS) -o $(NAME) $(INCS)
+		./srcs/test/test_maps.sh $(VALGRIND)
+
 
 -include $(DEPS)
 

--- a/include/cub3d.h
+++ b/include/cub3d.h
@@ -6,7 +6,7 @@
 /*   By: elouisia <elouisia@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/06 15:54:20 by elouisia          #+#    #+#             */
-/*   Updated: 2022/09/26 09:30:41 by aweaver          ###   ########.fr       */
+/*   Updated: 2022/09/26 10:22:22 by aweaver          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,7 +63,6 @@ typedef struct s_cub_data
 	char	*we;
 	int		ceilling;
 	int		floor;
-	int		fd;
 	int		error;
 	t_list	*lst_map;
 }				t_cub_data;

--- a/include/cub3d.h
+++ b/include/cub3d.h
@@ -6,7 +6,7 @@
 /*   By: elouisia <elouisia@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/06 15:54:20 by elouisia          #+#    #+#             */
-/*   Updated: 2022/09/23 08:25:59 by aweaver          ###   ########.fr       */
+/*   Updated: 2022/09/26 09:30:41 by aweaver          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,7 +42,7 @@
 # endif
 
 # ifndef NOT_FOUND
-#  define NOT_FOUND 1
+#  define NOT_FOUND 2
 # endif
 
 # ifndef DEBUG

--- a/maps/default.cub
+++ b/maps/default.cub
@@ -1,7 +1,7 @@
-NO ./path_to_north_texture
-SO ./path_to_south_texture
-WE ./path_to_west_texture
-EA ./path_to_east_texture
+NO images/blue_wall.xpm
+SO images/red_brick.xpm
+WE images/brown_wall.xpm
+EA images/grey_wall.xpm
 
 F 220,100,0
 C 225,30,0

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -6,7 +6,7 @@
 /*   By: elouisia <elouisia@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/06 15:52:30 by elouisia          #+#    #+#             */
-/*   Updated: 2022/09/20 10:22:26 by aweaver          ###   ########.fr       */
+/*   Updated: 2022/09/26 10:22:44 by aweaver          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,7 +40,6 @@ void	ft_init_data(t_cub_data *data)
 	data->we = NULL;
 	data->ceilling = -1;
 	data->floor = -1;
-	data->fd = -1;
 	data->error = 0;
 	data->lst_map = NULL;
 }

--- a/srcs/parsing/check_ceilling_floor_texture_functions.c
+++ b/srcs/parsing/check_ceilling_floor_texture_functions.c
@@ -6,7 +6,7 @@
 /*   By: aweaver <aweaver@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/19 11:31:41 by aweaver           #+#    #+#             */
-/*   Updated: 2022/09/26 09:52:36 by aweaver          ###   ########.fr       */
+/*   Updated: 2022/09/26 10:44:21 by aweaver          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -86,8 +86,7 @@ int	ft_check_floor(t_map_data *map)
 	while (++i < 3)
 	{
 		if (ft_check_value(map->flag_and_path[i], &rgb[i]) == 1)
-			return (ft_free_strptr(map->flag_and_path),
-				ft_wrong_map_exit(map->data->lst_map, "Texture F: ",
+			return (ft_wrong_map_exit(map->data->lst_map, "Texture F: ",
 					"not a valid colour"), 1);
 	}
 	ft_check_redefinition(map, "F: ", &(map->data->floor),
@@ -114,8 +113,7 @@ int	ft_check_ceilling(t_map_data *map)
 	while (++i < 3)
 	{
 		if (ft_check_value(map->flag_and_path[i], &rgb[i]) == 1)
-			return (ft_free_strptr(map->flag_and_path),
-				ft_wrong_map_exit(map->data->lst_map, "Texture C: ",
+			return (ft_wrong_map_exit(map->data->lst_map, "Texture C: ",
 					"not a valid colour"), 1);
 	}
 	ft_check_redefinition(map, "C: ", &(map->data->ceilling),

--- a/srcs/parsing/check_ceilling_floor_texture_functions.c
+++ b/srcs/parsing/check_ceilling_floor_texture_functions.c
@@ -6,7 +6,7 @@
 /*   By: aweaver <aweaver@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/19 11:31:41 by aweaver           #+#    #+#             */
-/*   Updated: 2022/09/23 09:20:20 by aweaver          ###   ########.fr       */
+/*   Updated: 2022/09/26 09:52:36 by aweaver          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,10 +72,11 @@ int	ft_check_floor(t_map_data *map)
 	int		rgb[3];
 	int		i;
 
-	tmp = ft_strptr_to_str(map->flag_and_path + 1);
+	tmp = ft_strptr_to_str(&(map->flag_and_path[1]));
 	map->flag_and_path = ft_free_strptr(map->flag_and_path);
 	map->flag_and_path = ft_split(tmp, ',');
 	free(tmp);
+	tmp = NULL;
 	if (ft_strptr_len(map->flag_and_path) != 3)
 	{
 		ft_free_strptr(map->flag_and_path);
@@ -84,8 +85,8 @@ int	ft_check_floor(t_map_data *map)
 	i = -1;
 	while (++i < 3)
 	{
-		if (ft_check_value(tmp, &rgb[i]) == 1)
-			return (free(tmp), ft_free_strptr(map->flag_and_path),
+		if (ft_check_value(map->flag_and_path[i], &rgb[i]) == 1)
+			return (ft_free_strptr(map->flag_and_path),
 				ft_wrong_map_exit(map->data->lst_map, "Texture F: ",
 					"not a valid colour"), 1);
 	}
@@ -100,7 +101,7 @@ int	ft_check_ceilling(t_map_data *map)
 	int		rgb[3];
 	int		i;
 
-	tmp = ft_strptr_to_str(map->flag_and_path + 1);
+	tmp = ft_strptr_to_str(&(map->flag_and_path[1]));
 	map->flag_and_path = ft_free_strptr(map->flag_and_path);
 	map->flag_and_path = ft_split(tmp, ',');
 	free(tmp);
@@ -112,12 +113,12 @@ int	ft_check_ceilling(t_map_data *map)
 	i = -1;
 	while (++i < 3)
 	{
-		if (ft_check_value(tmp, &rgb[i]) == 1)
-			return (free(tmp), ft_free_strptr(map->flag_and_path),
+		if (ft_check_value(map->flag_and_path[i], &rgb[i]) == 1)
+			return (ft_free_strptr(map->flag_and_path),
 				ft_wrong_map_exit(map->data->lst_map, "Texture C: ",
 					"not a valid colour"), 1);
 	}
-	ft_check_redefinition(map, "C: ", &(map->data->floor),
+	ft_check_redefinition(map, "C: ", &(map->data->ceilling),
 		ft_get_argb(0, rgb[0], rgb[1], rgb[2]));
 	return (0);
 }

--- a/srcs/parsing/check_wall_texture_functions.c
+++ b/srcs/parsing/check_wall_texture_functions.c
@@ -6,7 +6,7 @@
 /*   By: aweaver <aweaver@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/19 11:05:24 by aweaver           #+#    #+#             */
-/*   Updated: 2022/09/23 08:28:19 by aweaver          ###   ########.fr       */
+/*   Updated: 2022/09/26 09:31:45 by aweaver          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,7 +26,7 @@ int	ft_check_path(char *path)
 	if (fd < 0)
 		return (NOT_FOUND);
 	line = get_next_line(fd);
-	if (line == NULL || ft_strcmp(line, "/* XPM */") != 0)
+	if (line == NULL || ft_strcmp(line, "/* XPM */\n") != 0)
 	{
 		free(line);
 		line = NULL;

--- a/srcs/parsing/map_to_list.c
+++ b/srcs/parsing/map_to_list.c
@@ -6,7 +6,7 @@
 /*   By: elouisia <elouisia@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/07 16:04:09 by elouisia          #+#    #+#             */
-/*   Updated: 2022/09/20 18:11:16 by aweaver          ###   ########.fr       */
+/*   Updated: 2022/09/26 10:42:09 by aweaver          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,28 +39,27 @@ int	add_line_map(char *line, t_cub_data *data)
 int	map_to_list(t_cub_data *data, char *map_file)
 {
 	char		*line;
+	int			fd;
 
-	data->fd = open(map_file, O_RDONLY);
+	fd = open(map_file, O_RDONLY);
 	if (ft_check_name(map_file) == WRONG_MAP_NAME)
 		return (WRONG_MAP_NAME);
-	if (data->fd < 1)
+	if (fd < 1)
 		return (ft_err_msg(strerror(errno)));
 	ft_check_map_content(data);
-	line = get_next_line(data->fd);
+	line = get_next_line(fd);
 	if (line == NULL)
-		return (ft_err_msg("Empty map."));
+		return (close(fd), ft_err_msg("Empty map."));
 	if (add_line_map(line, data) == WRONG_MALLOC)
-		return (ft_err_msg("Malloc error."));
+		return (close(fd), ft_err_msg("Malloc error."));
 	while (line)
 	{
-		line = get_next_line(data->fd);
-		if (!line)
-			break ;
-		if (add_line_map(line, data) == WRONG_MALLOC)
+		line = get_next_line(fd);
+		if (line && add_line_map(line, data) == WRONG_MALLOC)
 			return (get_next_line(GNL_FLUSH), ft_err_msg("Malloc error."));
 	}
-	close(data->fd);
 	ft_lstiter(data->lst_map, &print_lst_map);
 	ft_putstr_fd("\n", 1);
+	close(fd);
 	return (0);
 }

--- a/srcs/test/main_map_tester.c
+++ b/srcs/test/main_map_tester.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   main.c                                             :+:      :+:    :+:   */
+/*   main_map_tester.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: elouisia <elouisia@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/09/06 15:52:30 by elouisia          #+#    #+#             */
-/*   Updated: 2022/09/08 18:04:57 by elouisia         ###   ########.fr       */
+/*   Updated: 2022/09/26 10:45:27 by aweaver          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,7 +22,6 @@ void	ft_init_data(t_cub_data *data)
 	data->we = NULL;
 	data->ceilling = -1;
 	data->floor = -1;
-	data->fd = -1;
 	data->error = 0;
 	data->lst_map = NULL;
 }
@@ -41,5 +40,6 @@ int	main(int ac, char **av)
 		return (0);
 	ft_check_map_content(&data);
 	printf("Main would have started a mlx window\n");
+	ft_lstclear(&(data.lst_map), ft_clear_map);
 	return (0);
 }

--- a/srcs/test/test_maps.sh
+++ b/srcs/test/test_maps.sh
@@ -4,22 +4,22 @@
 chmod 000 ./maps/forbidden.cub;
 echo "======= THE FOLLOWING SHOULD FAIL ======="
 echo -e "\n\nTESTING MAP FORBIDDEN"
-./cub3D ./maps/forbidden.cub
+$@ ./cub3D ./maps/forbidden.cub
 echo "Tester returned $?"
 echo -e "\n\nTESTING MAP WITH NO .CUB EXTENSION"
-./cub3D ./maps/nocub
+$@ ./cub3D ./maps/nocub
 echo "Tester returned $?"
 echo -e "\n\nTESTING MAP WITH NO NAME WITH .CUB EXTENSION"
-./cub3D ./maps/.cub
+$@ ./cub3D ./maps/.cub
 echo "Tester returned $?"
 echo -e "\n\nTESTING EMPTY MAP"
-./cub3D ./maps/empty.cub
+$@ ./cub3D ./maps/empty.cub
 echo "Tester returned $?"
 echo -e "\n\nTESTING INCORRECT MAP 1"
-./cub3D ./maps/broken.cub
+$@ ./cub3D ./maps/broken.cub
 echo "Tester returned $?"
 echo "======= THE FOLLOWING SHOULD SUCCEED ======="
 echo -e "\n\nTESTING CORRECT MAP"
-./cub3D ./maps/default.cub
+$@ ./cub3D ./maps/default.cub
 echo "Tester returned $?"
 chmod 400 ./maps/forbidden.cub;


### PR DESCRIPTION
Fixing leaks in specific cases (incorrect colours, incorrect walls, correct walls and colours).

Adding new Makefile rule vtest_map, using valgrind when testing all maps.
Removing fd, from data structure.

Changing default map with new xpm files.
Program is now behaving as expected with all the existing maps.
Some errors (map unamed with .cub extension) may still be changed to be more explicit.

Fix #3 
